### PR TITLE
Fix data path in tests

### DIFF
--- a/wluncert/tests/test_basic.py
+++ b/wluncert/tests/test_basic.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from eda4uncert.bayesinference import PyroMCMCRegressor
@@ -15,8 +16,13 @@ class TestStringMethods(unittest.TestCase):
         assert is_valid_grammar(US_PHONE_GRAMMAR, supported_opts={'prob'})
 
     def test_train_test_data(self):
-        sys = ConfSysData(
-            "/home/jdorn/code/probabilistic-regression/SupplementaryWebsite/MeasuredPerformanceValues/x264/measurements-cleared.csv")
+        data_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "training-data",
+            "h2.csv",
+        )
+        sys = ConfSysData(data_path)
         sys.test_train_split()
         return sys
 


### PR DESCRIPTION
## Summary
- fix `test_train_test_data` to use repo-relative dataset path

## Testing
- `pytest wluncert/tests/test_basic.py::TestStringMethods::test_train_test_data -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*

------
https://chatgpt.com/codex/tasks/task_e_6859ba39886c833091d4e53430231618