### PR TITLE
Fix reuse of standard scaler in normalized data

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -190,9 +190,11 @@ class SingleEnvDataNormalized(SingleEnvData):
         for nfp_name in self.nfps:
             y = np.atleast_2d(self.get_y(nfp_name)).T
             if scaler:
-                y_scaled = scaler[nfp_name].transform(y)
-            y_scaler = StandardScaler()
-            y_scaled = y_scaler.fit_transform(y)
+                y_scaler = scaler[nfp_name]
+            else:
+                y_scaler = StandardScaler()
+                y_scaler.fit(y)
+            y_scaled = y_scaler.transform(y)
             self.df[nfp_name] = y_scaled.ravel()
             self.scaler_y[nfp_name] = y_scaler
 


### PR DESCRIPTION
## Summary
- correct handling of provided scaler in `normalize_y`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*

------
https://chatgpt.com/codex/tasks/task_e_6859addd83248330a7bec0a557f23f73