### PR TITLE
Add TuxKconfig dataset adapter

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -758,6 +758,38 @@ class DataAdapterArtificial(DataAdapter):
         return noisy_df
 
 
+class DataAdapterTuxKconfig(DataAdapter):
+    """Adapter for the TuxKConfig dataset aggregated from OpenML"""
+
+    def __init__(self, data_loader: DataLoaderStandard):
+        self.environment_col_name = "version"
+        self.nfps = ["binary_size"]
+        self.environment_lables = None
+        super().__init__(data_loader, self.environment_col_name)
+
+    def get_environment_col_name(self):
+        return self.environment_col_name
+
+    def get_environment_lables(self):
+        return list(self.environment_lables)
+
+    def get_nfps(self):
+        return self.nfps
+
+    def get_transformed_df(
+        self,
+        cleared_sys_df,
+    ):
+        cleared_sys_df = self.factorize_workload_col(cleared_sys_df)
+        all_cols = cleared_sys_df.columns
+        middle_cols = [self.environment_col_name]
+        options = set(all_cols) - {*self.nfps, *middle_cols}
+        cleared_sys_df = cleared_sys_df[
+            [*options, self.environment_col_name, *self.nfps]
+        ]
+        return cleared_sys_df
+
+
 def remove_multicollinearity(df):
     return util.remove_multicollinearity(df)
 

--- a/wluncert/main.py
+++ b/wluncert/main.py
@@ -38,6 +38,7 @@ from data import (
     DataAdapterFastdownward,
     DataAdapterArtificial,
     DataAdapterVP9,
+    DataAdapterTuxKconfig,
 )
 
 from datanfp import (
@@ -605,6 +606,7 @@ def get_datasets(train_data_folder=None, dataset_lbls=None):
     lbl_nfp_PostgreSQL = "nfp-PostgreSQL"
     lbl_nfp_VP8 = "nfp-VP8"
     lbl_nfp_x264 = "nfp-x264"
+    lbl_tuxkconfig = "tuxkconfig"
     lbl_VP9 = "VP9"
     all_lbls = [
         lbl_jump_r,
@@ -634,6 +636,7 @@ def get_datasets(train_data_folder=None, dataset_lbls=None):
         lbl_nfp_PostgreSQL,
         lbl_nfp_VP8,
         lbl_nfp_x264,
+        lbl_tuxkconfig,
     ]
     dataset_lbls = dataset_lbls or all_lbls
 
@@ -741,6 +744,17 @@ def get_datasets(train_data_folder=None, dataset_lbls=None):
         data_x265 = DataAdapterVP9(x265_data_raw)
         x265_wl_data: WorkloadTrainingDataSet = data_x265.get_wl_data()
         data_providers[lbl_x265] = x265_wl_data
+
+    if lbl_tuxkconfig in dataset_lbls:
+        path_tuxkc = os.path.join(
+            train_data_folder,
+            "tuxkconfig_datasets",
+            "tuxkconfig_merged.csv",
+        )
+        tuxkc_data_raw = DataLoaderStandard(path_tuxkc)
+        data_tuxkc = DataAdapterTuxKconfig(tuxkc_data_raw)
+        tuxkc_wl_data: WorkloadTrainingDataSet = data_tuxkc.get_wl_data()
+        data_providers[lbl_tuxkconfig] = tuxkc_wl_data
 
     ############
     # NFP DATA #


### PR DESCRIPTION
## Summary
- add new DataAdapterTuxKconfig
- expose the adapter through `get_datasets`
- fix TuxKconfig merged CSV path

## Testing
- `black wluncert/data.py wluncert/main.py --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*


------
https://chatgpt.com/codex/tasks/task_e_6859beee9ba08330a0ff7d69ac86d15e