### PR TITLE
Support tuxkconfig parquet dataset

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -297,7 +297,10 @@ class DataLoaderStandard:
         self.sep = sep
 
     def get_standard_CSV(self):
-        sys_df = pd.read_csv(self.base_path, sep=self.sep)
+        if str(self.base_path).endswith(".parquet"):
+            sys_df = pd.read_parquet(self.base_path)
+        else:
+            sys_df = pd.read_csv(self.base_path, sep=self.sep)
         df_no_multicollinearity = remove_multicollinearity(sys_df)
         cleared_sys_df = copy.deepcopy(df_no_multicollinearity)
         return cleared_sys_df

--- a/wluncert/main.py
+++ b/wluncert/main.py
@@ -758,7 +758,7 @@ def get_datasets(train_data_folder=None, dataset_lbls=None):
         path_tuxkc = os.path.join(
             train_data_folder,
             "tuxkconfig_datasets",
-            "tuxkconfig_merged.csv",
+            "tuxkconfig_merged.parquet",
         )
         tuxkc_data_raw = DataLoaderStandard(path_tuxkc)
         data_tuxkc = DataAdapterTuxKconfig(tuxkc_data_raw)


### PR DESCRIPTION
## Summary
- handle parquet files in `DataLoaderStandard`
- update TuxKConfig dataset path to parquet in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*

------
https://chatgpt.com/codex/tasks/task_e_685ae2119d80833089225fbae70ec384