### PR TITLE
Set default max_train samples

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -106,14 +106,16 @@ class SingleEnvData:
         n_train_samples_abs=None,
         n_train_samples_rel_opt_num=None,
         rnd=0,
-        max_train_samples_rel_opt_num=None,
+        max_train_samples_rel_opt_num=10000,
         max_test_samples_abs=None,
     ):
         """Return a train/test split.
 
-        If ``max_train_samples_rel_opt_num`` is given, the test set comprises all
-        samples that are **not** part of the largest training subset determined
-        by this parameter. Smaller training sets are sampled from that largest
+        ``max_train_samples_rel_opt_num`` defines the relative size of the
+        largest training subset used for deriving smaller training sets. By
+        default this value is ``10000``. The test set consists of all samples
+        that are **not** part of the largest training subset determined by this
+        parameter. Smaller training sets are sampled from that largest
         training subset so that every training set is contained in it.
 
         ``max_test_samples_abs`` can be used to further subsample the resulting


### PR DESCRIPTION
## Summary
- default `max_train_samples_rel_opt_num` to 10000
- document the new default in `get_split`

## Testing
- `python -m py_compile wluncert/data.py`

------
https://chatgpt.com/codex/tasks/task_e_685aeb5d0bf08330b36f7506d22141b6