### PR TITLE
Add limited multicollinearity removal

### DIFF
--- a/wluncert/tests/test_multicollinearity.py
+++ b/wluncert/tests/test_multicollinearity.py
@@ -1,0 +1,87 @@
+import unittest
+import pandas as pd
+import numpy as np
+import time
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "utils", Path(__file__).resolve().parents[1] / "utils.py"
+)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+import sys
+sys.modules["utils"] = utils
+remove_multicollinearity = utils.remove_multicollinearity
+remove_multicollinearity_limited = utils.remove_multicollinearity_limited
+
+
+def make_large_df(n_groups=50, group_size=3, n_rows=200):
+    rng = np.random.default_rng(0)
+    data = {}
+    for i in range(n_groups):
+        choices = rng.integers(0, group_size, size=n_rows)
+        for j in range(group_size):
+            col_name = f"G{i}_{j}"
+            data[col_name] = (choices == j).astype(int)
+    return pd.DataFrame(data)
+
+
+class TestRemoveMulticollinearity(unittest.TestCase):
+    def _baseline_original(self, df):
+        """Original implementation using nx.find_cliques."""
+        from utils import _sample_df, factorize_if_not_int, _pairwise_exclusive_mask
+        import networkx as nx
+
+        nunique = df.nunique()
+        drop_cols = list(nunique[nunique == 1].index)
+        if "Unnamed: 0" in df.columns:
+            drop_cols.append("Unnamed: 0")
+        df.drop(columns=drop_cols, inplace=True, errors="ignore")
+        if df.empty:
+            return df
+
+        df_sampled = _sample_df(df, max_rows=100)
+        arr = factorize_if_not_int(df_sampled)
+        features = list(df.columns)
+        mask = _pairwise_exclusive_mask(arr)
+
+        G = nx.Graph()
+        for i in range(len(features)):
+            for j in range(i + 1, len(features)):
+                if mask[i, j]:
+                    G.add_edge(features[i], features[j])
+
+        while True:
+            cliques = list(nx.find_cliques(G))
+            for clique in cliques:
+                if df_sampled[list(clique)].sum(axis=1).eq(1).all():
+                    to_drop = sorted(clique)[0]
+                    df.drop(columns=[to_drop], inplace=True)
+                    df_sampled.drop(columns=[to_drop], inplace=True)
+                    G.remove_node(to_drop)
+                    break
+            else:
+                break
+
+        return df
+
+    def test_large_dataframe_speed(self):
+        df = make_large_df()
+
+        t0 = time.time()
+        limited = remove_multicollinearity_limited(df.copy())
+        t_limited = time.time() - t0
+
+        t0 = time.time()
+        baseline = self._baseline_original(df.copy())
+        t_baseline = time.time() - t0
+
+        self.assertLess(limited.shape[1], df.shape[1])
+        self.assertEqual(limited.shape[1], baseline.shape[1])
+        self.assertLess(t_limited, t_baseline)
+        self.assertLess(t_limited, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wluncert/utils.py
+++ b/wluncert/utils.py
@@ -19,10 +19,6 @@ def _pairwise_exclusive_mask(arr: np.ndarray) -> np.ndarray:
     return (co_occurrence == 0) & (on_counts[:, None] > 0) & (on_counts[None, :] > 0)
 
 
-import pandas as pd
-import numpy as np
-
-
 def factorize_if_not_int(df: pd.DataFrame) -> np.ndarray:
     df_factorized = df.copy()
 
@@ -37,7 +33,76 @@ def factorize_if_not_int(df: pd.DataFrame) -> np.ndarray:
     return df_factorized.astype(int).to_numpy()
 
 
+def remove_multicollinearity_limited(
+    df: pd.DataFrame, sample_rows: int = 100, max_clique_size: int = 5
+) -> pd.DataFrame:
+    """Remove redundant mutually exclusive columns using limited clique search.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe.
+    sample_rows : int, optional
+        Number of rows to sample when constructing the exclusivity graph.
+    max_clique_size : int, optional
+        Maximum size of cliques to consider when removing columns.
+    """
+
+    print("⏳ Removing multicollinearity (limited)...", end=" ")
+
+    nunique = df.nunique()
+    drop_cols = list(nunique[nunique == 1].index)
+    if "Unnamed: 0" in df.columns:
+        drop_cols.append("Unnamed: 0")
+    df.drop(columns=drop_cols, inplace=True, errors="ignore")
+    print(f"\n🧹 Dropped {len(drop_cols)} constant/index columns.", end=" ")
+
+    if df.empty:
+        print("⚠️ Empty DataFrame after cleanup. Skipping.")
+        return df
+
+    print("\n🔍 Sampling ...", end=" ", flush=True)
+    df_sampled = _sample_df(df, max_rows=sample_rows)
+    print(" and computing exclusive masks...", end=" ", flush=True)
+    arr = factorize_if_not_int(df_sampled)
+
+    features = list(df.columns)
+    mask = _pairwise_exclusive_mask(arr)
+    print("Done.")
+
+    print("🧱 Building exclusivity graph...", end=" ")
+    G = nx.Graph()
+    for i in range(len(features)):
+        for j in range(i + 1, len(features)):
+            if mask[i, j]:
+                G.add_edge(features[i], features[j])
+    print(f"{G.number_of_nodes()} nodes, {G.number_of_edges()} edges.")
+
+    print("🧹 Removing redundant cliques...", end=" ")
+    removed = 0
+    for clique in nx.enumerate_all_cliques(G):
+        if len(clique) > max_clique_size:
+            break
+        if len(clique) < 2:
+            continue
+        if not all(col in df_sampled.columns for col in clique):
+            continue
+        if df_sampled[list(clique)].sum(axis=1).eq(1).all():
+            to_drop = sorted(clique)[0]
+            df.drop(columns=[to_drop], inplace=True)
+            df_sampled.drop(columns=[to_drop], inplace=True)
+            G.remove_node(to_drop)
+            removed += 1
+    print(f"{removed} features removed.")
+
+    print("✅ Done.")
+    return df
+
+
 def remove_multicollinearity(df: pd.DataFrame, sample_rows: int = 100) -> pd.DataFrame:
+    if len(df.columns) > 100:
+        return remove_multicollinearity_limited(df, sample_rows=sample_rows)
+
     print("⏳ Removing multicollinearity...", end=" ")
 
     # Drop constant/index columns


### PR DESCRIPTION
## Summary
- introduce `remove_multicollinearity_limited` with bounded clique enumeration
- call limited version when a dataframe has more than 100 columns
- add regression test for large dataframes
- test now measures speed vs the original approach

## Testing
- `python wluncert/tests/test_multicollinearity.py`


------
https://chatgpt.com/codex/tasks/task_e_6866ef0c86c883308a4acd5e6eb47685