### PR TITLE
Capture Binary_Size target when downloading Tux data

### DIFF
--- a/wluncert/training-data/getTuxKConfig.py
+++ b/wluncert/training-data/getTuxKConfig.py
@@ -40,7 +40,8 @@ for name, dataset_id, version in datasets:
         try:
             print(f"⬇️ Downloading {name} (ID: {dataset_id})")
             dataset = openml.datasets.get_dataset(dataset_id)
-            df, *_ = dataset.get_data()
+            df, y, *_ = dataset.get_data(target="Binary_Size")
+            df["Binary_Size"] = y
             if USE_PARQUET:
                 df.to_parquet(file_path)
             else:
@@ -51,6 +52,9 @@ for name, dataset_id, version in datasets:
             continue
 
     df["version"] = version
+    if "Binary_Size" in df.columns:
+        columns = [c for c in df.columns if c != "Binary_Size"] + ["Binary_Size"]
+        df = df[columns]
     merged_df = pd.concat([merged_df, df], ignore_index=True)
 
 if USE_PARQUET:


### PR DESCRIPTION
## Summary
- ensure Binary_Size is included when fetching each TuxKConfig dataset
- keep Binary_Size as the last column when saving

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*

------
https://chatgpt.com/codex/tasks/task_e_68681ad1aa34833095efb4b86d524454