### PR TITLE
Add debug prints for dataset loading and tasks

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -324,13 +324,19 @@ class DataLoaderStandard:
 
     def get_standard_CSV(self):
         if str(self.base_path).endswith(".parquet"):
-            print("start reading parquet")
+            print(f"start reading parquet {self.base_path}", flush=True)
             sys_df = pd.read_parquet(self.base_path, engine="pyarrow")
-            print("end reading parquet")
+            print(f"end reading parquet shape={sys_df.shape}", flush=True)
         else:
+            print(f"start reading csv {self.base_path}", flush=True)
             sys_df = pd.read_csv(self.base_path, sep=self.sep)
+            print(f"csv loaded shape={sys_df.shape}", flush=True)
         df_no_multicollinearity = remove_multicollinearity(sys_df)
         cleared_sys_df = copy.deepcopy(df_no_multicollinearity)
+        print(
+            f"data after removing multicollinearity shape={cleared_sys_df.shape}",
+            flush=True,
+        )
         return cleared_sys_df
 
     def get_df(self):

--- a/wluncert/experiment.py
+++ b/wluncert/experiment.py
@@ -382,6 +382,10 @@ class Replication:
 
     def provision_experiment(self, args):
         model_lbl, model_proto, data_lbl, data_set, train_size, rnd = args
+        print(
+            f"provisioning model={model_lbl} data={data_lbl} train_size={train_size} rnd={rnd}",
+            flush=True,
+        )
         max_train_size = max(self.train_sizes_relative_to_option_number)
         data_per_env: List[SingleEnvData] = data_set.get_workloads_data()
         train_list = []
@@ -424,6 +428,11 @@ class Replication:
                 rnd=rnd,
             )
             tasks.append(new_task)
+
+        print(
+            f"finished provisioning {len(tasks)} tasks for model={model_lbl} data={data_lbl}",
+            flush=True,
+        )
 
         return tasks
 
@@ -484,10 +493,12 @@ class Replication:
         mlflow.set_tracking_uri(MLFLOW_URI)
         mlflow.set_experiment(experiment_name=EXPERIMENT_NAME)
         run_name = task.get_id()
+        print(f"starting task {run_name}", flush=True)
         with mlflow.start_run(run_id=self.parent_run_id):
             with mlflow.start_run(run_name=run_name, nested=True):
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=UserWarning)
                     task.run()
+        print(f"finished task {run_name}", flush=True)
         del task.model
         del task


### PR DESCRIPTION
## Summary
- add dataset loading prints to `DataLoaderStandard.get_standard_CSV`
- show provisioning and finished messages in `Replication.provision_experiment`
- print start/finish messages when running tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eda4uncert')*

------
https://chatgpt.com/codex/tasks/task_e_686ad2fe09f48330afaad31e5fd0a866