### PR TITLE
Fix HyPerf label text in micro RQ dashboard

### DIFF
--- a/wluncert/playground/microRQdashboard.py
+++ b/wluncert/playground/microRQdashboard.py
@@ -1388,7 +1388,7 @@ def draw_multitask_large_comparison(
     # ensure consistent labelling between the table and the plot we map the
     # remaining Bayesian rows to the HyPerf label before dropping the pooling
     # category column.
-    bpp = "$\\tilde{\\Pi}^\\text{pp} (HyPerf)$"
+    bpp = "HyPerf ($\\tilde{\\Pi}^\\text{pp}$)"
     unwanted_pooling = ["complete", "no"]
     time_df = time_df.loc[
         ~(
@@ -1418,7 +1418,7 @@ def draw_multitask_large_comparison(
     ]
 
     bnp = "$\\tilde{\Pi}^\\text{np}$"
-    bpp = "$\\tilde{\\Pi}^\\text{pp} (HyPerf)$"
+    bpp = "HyPerf ($\\tilde{\\Pi}^\\text{pp}$)"
     bcp = "$\\tilde{\\Pi}^\\text{cp}$"
     melted_df[model_lbl].loc[
         (melted_df[model_lbl] == "Bayesian") & (melted_df[pooling_cat_lbl] == "no")


### PR DESCRIPTION
## Summary
- update HyPerf label for large model comparison in the micro RQ dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686f8778c8cc8330a63af97e2c30ba48