### PR TITLE
Fix seaborn plotting when pooling category missing

### DIFF
--- a/wluncert/mlfloweval.py
+++ b/wluncert/mlfloweval.py
@@ -60,6 +60,13 @@ class MultitaskPlotter(Plotter):
         )
 
         metric = "metrics.mape_overall"
+        style_col = "params.pooling_cat"
+        style_arg = (
+            {"style": style_col}
+            if melted_df[style_col].notna().any()
+            else {}
+        )
+
         plot = sns.relplot(
             data=melted_df,
             x="params.relative_train_size",
@@ -71,8 +78,8 @@ class MultitaskPlotter(Plotter):
             # sharey=False,
             kind="line",
             hue="params.model",
-            style="params.pooling_cat",
             facet_kws={"sharey": False, "sharex": False},
+            **style_arg,
         )
         # setting boundaries that make sense
         plt.tight_layout()


### PR DESCRIPTION
## Summary
- guard style parameter in plotting when `params.pooling_cat` is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686f921cbde4833083047814bfe700f1