### PR TITLE
Fix TuxKconfig NaN handling

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -827,6 +827,8 @@ class DataAdapterTuxKconfig(DataAdapter):
         cleared_sys_df = cleared_sys_df[
             [*options, self.environment_col_name, *self.nfps]
         ]
+        # replace NaN values with 0 (OpenML data may contain missing entries)
+        cleared_sys_df = cleared_sys_df.fillna(0)
         return cleared_sys_df
 
 


### PR DESCRIPTION
## Summary
- fill missing entries with `0` in the TuxKconfig data adapter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymoo')*

------
https://chatgpt.com/codex/tasks/task_e_686f9ed09cc88330a9c39fef01412959