### PR TITLE
Fix NaN handling for TuxKconfig

### DIFF
--- a/wluncert/data.py
+++ b/wluncert/data.py
@@ -820,6 +820,9 @@ class DataAdapterTuxKconfig(DataAdapter):
         self,
         cleared_sys_df,
     ):
+        # Replace missing values with 0 to avoid errors in models that
+        # cannot handle NaNs (e.g., RandomForestRegressor).
+        cleared_sys_df = cleared_sys_df.fillna(0)
         cleared_sys_df = self.factorize_workload_col(cleared_sys_df)
         all_cols = cleared_sys_df.columns
         middle_cols = [self.environment_col_name]


### PR DESCRIPTION
## Summary
- replace NaNs with 0 for the TuxKconfig dataset

## Testing
- `pytest wluncert/tests/test_multicollinearity.py::TestRemoveMulticollinearity::test_large_dataframe_speed -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_686f9ed09cc88330a9c39fef01412959