### PR TITLE
Fix memory leak in experiments

### DIFF
--- a/wluncert/main.py
+++ b/wluncert/main.py
@@ -372,6 +372,8 @@ def main():
     eval = mlfloweval.Evaluation(run_id, MLFLOW_URI, EXPERIMENT_NAME)
     eval.run()
 
+    rep.release_resources()
+
     # eval.plot_errors()
 
 


### PR DESCRIPTION
## Summary
- free large objects after experiments finish
- call `release_resources` from `main`

## Testing
- `pytest wluncert/tests/test_recursive_dividing.py::TestRecursiveDividing::test_divisions_match_expected_samples -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd39db1b0833081051eec08be65b0