### PR TITLE
Add max memory metric logging

### DIFF
--- a/wluncert/tests/test_memory_logging.py
+++ b/wluncert/tests/test_memory_logging.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import json
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from wluncert import localflow as mlflow
+
+
+def test_memory_metric_logged(tmp_path):
+    mlflow.RESULT_ROOT = str(tmp_path) + "/"
+    experiment_name = "memtest"
+    mlflow.set_experiment(experiment_name)
+    with mlflow.start_run(run_name="run") as run:
+        data = [0] * 10000
+        del data
+    exp_folder = mlflow.get_experiment_folder(experiment_name)
+    run_id = os.listdir(exp_folder)[0]
+    metrics_path = os.path.join(exp_folder, run_id, mlflow.METRICS_FILE)
+    with open(metrics_path) as f:
+        metrics = json.load(f)
+    assert "metrics.max_memory_mb" in metrics
+    assert metrics["metrics.max_memory_mb"] > 0


### PR DESCRIPTION
## Summary
- record maximum memory usage in LocalTask
- tolerate missing optional dependency `arviz`
- add regression test for memory logging

## Testing
- `pytest wluncert/tests/test_memory_logging.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_687636928b588330a839d989cd9433c9